### PR TITLE
improvements to voglperfrun: allow spaces and arguments to programs

### DIFF
--- a/src/voglperfrun.cpp
+++ b/src/voglperfrun.cpp
@@ -111,7 +111,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
                     //fprintf(stderr, "\nERROR: Unknown argument: %s\n\n", arg);
                     //argp_state_help(state, stderr, ARGP_HELP_LONG | ARGP_HELP_EXIT_OK);
                     // These are actually arguments to our program, e.g. if the user wants to run "voglperfrun -- glxgears -info", here we get "-info"
-                    arguments->prog_args += std::string(" ") + state->argv[state->next - 1];
+                    arguments->prog_args += std::string(" \"") + state->argv[state->next - 1] + "\"";
                 }
                 else {
                     arguments->gameid = arg;


### PR DESCRIPTION
1. Previously the string constructed with 
   ld.launch_cmd = ld.VOGL_CMD_LINE + " " + ld.LD_PRELOAD + " " + ld.args.gameid;
   was passed to system(). But ld.args.gameid can contain spaces. This adds quotes. Not sure if single quotes would be a good idea.
2. Previously you couldn't run a program with arguments. Example:
   voglperfrun -- glxgears -info
   would not work because -info was treated as an argument to voglperfrun. I'm not sure what I did was how it is intended, but at least it works.
