### PR TITLE
Fix crash on systems with tuntap interfaces

### DIFF
--- a/src/voglutils.cpp
+++ b/src/voglutils.cpp
@@ -81,27 +81,30 @@ std::string get_ip_addr()
 
     for (struct ifaddrs *ifa = ifAddrStruct; ifa; ifa = ifa->ifa_next)
     {
-        if (ifa ->ifa_addr->sa_family == AF_INET)
+        if (ifa->ifa_addr != NULL ) // tuntap interfaces may return NULL here
         {
-            // IP4 address.
-            char addressBuffer[INET_ADDRSTRLEN];
-            void *tmpAddrPtr = &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            if (ifa ->ifa_addr->sa_family == AF_INET)
+            {
+                // IP4 address.
+                char addressBuffer[INET_ADDRSTRLEN];
+                void *tmpAddrPtr = &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
 
-            inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
+                inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
 
-            if (!(ifa->ifa_flags & IFF_LOOPBACK) || !ret4.length())
-                ret4 = addressBuffer;
-        }
-        else if (ifa->ifa_addr->sa_family == AF_INET6)
-        {
-            // IP6 address.
-            char addressBuffer[INET6_ADDRSTRLEN];
-            void *tmpAddrPtr=&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr;
+                if (!(ifa->ifa_flags & IFF_LOOPBACK) || !ret4.length())
+                    ret4 = addressBuffer;
+            }
+            else if (ifa->ifa_addr->sa_family == AF_INET6)
+            {
+                // IP6 address.
+                char addressBuffer[INET6_ADDRSTRLEN];
+                void *tmpAddrPtr=&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr;
 
-            inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
+                inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
 
-            if (!(ifa->ifa_flags & IFF_LOOPBACK) || !ret6.length())
-                ret6 = addressBuffer;
+                if (!(ifa->ifa_flags & IFF_LOOPBACK) || !ret6.length())
+                    ret6 = addressBuffer;
+            }
         }
     }
 


### PR DESCRIPTION
In voglutils.cpp: getifaddrs() returns a linked list
of network interfaces of type 'struct ifAddrStruct'.
This may include tuntap interfaces of which the ifa->addr is NULL
To replicate this behaviour one can add a tuntap interface like this:
$ sudo ip tuntap add tun99 mode tun
To remove the previously created tuntap interface:
$ sudo ip tuntap del tun99 mode tun
These tuntap devices may be created by VPN software such as
OpenVPN.

To work around this, we simply check whether
ifa->addr is not NULL before proceeding.
