### PR TITLE
Added License and Credit Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,39 @@ Example Screenshot
 ------------------
 
 ![Example screenshot](https://raw.github.com/ValveSoftware/voglperf/master/screenshot.png)
+
+
+License and Credits
+-------------------
+voglperf code is under the [MIT](http://opensource.org/licenses/MIT) License. The license file [Repository License](https://github.com/ValveSoftware/voglperf/blob/master/LICENSE) is stored within the repository (and is reproduced here):
+```
+                       VOGLPERF CODE  LICENSE
+
+  Copyright 2013-2014 RAD Game Tools and Valve Software
+  All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+```
+
+`src/eintr_wrapper.h`- Chromium Authors (2012); BSD-style License. [Current License] (https://chromium.googlesource.com/chromium/src.git/+/master/LICENSE)
+
+`src/webby/` - Andreas Fredriksson (2012); BSD-style License [Current License](https://github.com/ValveSoftware/voglperf/blob/master/src/webby/LICENSE); [Source Location](https://github.com/deplinenoise/webby)
+
+`src/libedit/` - Jess Thrysoee and NetBSD (2014); BSD-style License [Current License](http://www.netbsd.org/about/redistribution.html); [Source Location](http://thrysoee.dk/editline/)
+


### PR DESCRIPTION
Added the following section to README.md: License and Credits
Has a reproduction of the MIT license for voglperf.
List of external libraries and headers used by voglperf. [src/eintr_wrapper.h, src/webby/, src/libedit/]

Closes #20.
