### PR TITLE
Correction to fps example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Run vogl w/ SSH on SteamOS
   * Run various commands:
      * `help`
      * `status`
-     * `showfps on`
+     * `fpsshow on`
      * `game start 440`
      * etc.
 


### PR DESCRIPTION
`showfps on` does not exist. Per the help command, `fpsshow` is correct.