### PR TITLE
Fix several GCC warnings

### DIFF
--- a/src/voglperf.c
+++ b/src/voglperf.c
@@ -343,7 +343,7 @@ static int voglperf_logfile_open(const char *logfile_name, uint64_t seconds)
 
             g_logfile_time = seconds * 1000000000;
 
-            strncpy(g_logfile_name, logfile_name, sizeof(g_logfile_name));
+            strncpy(g_logfile_name, logfile_name, sizeof(g_logfile_name) - 1);
 
             if (g_msqid != -1)
             {

--- a/src/voglutils.cpp
+++ b/src/voglutils.cpp
@@ -783,7 +783,7 @@ void webby_update(std::vector<std::string> *commands, struct timeval *timeoutval
 //----------------------------------------------------------------------------------------------------------------------
 void webby_end()
 {
-    (void) webby_data().ws_connections.empty();
+    static_cast<void>(webby_data().ws_connections.empty());
 
     if (webby_data().server)
     {

--- a/src/voglutils.cpp
+++ b/src/voglutils.cpp
@@ -783,7 +783,7 @@ void webby_update(std::vector<std::string> *commands, struct timeval *timeoutval
 //----------------------------------------------------------------------------------------------------------------------
 void webby_end()
 {
-    webby_data().ws_connections.empty();
+    (void) webby_data().ws_connections.empty();
 
     if (webby_data().server)
     {


### PR DESCRIPTION
1. `webby_data().ws_connections.empty()` returns `boolean` but it's not handled anywhere. Casting with void will suppress it.
2. In line 346 `strncpy` is trying to copy the string on the destination which has the same size as the source string. It might overlap string size when the source will be at the same size as destination.